### PR TITLE
fix(date): make date field width more flexible

### DIFF
--- a/src/DateInput.tsx
+++ b/src/DateInput.tsx
@@ -48,7 +48,9 @@ const DateInputSelect = styled.select<DateInputSelectProps>(
     letter-spacing: 0.6px;
     margin: 0;
     min-height: 48px;
-    padding: ${theme.space.sm};
+    padding: ${theme.space.sm} 6px;
+    text-align: center;
+    max-width: 33.333333%;
     background: transparent;
     color: ${hasValue ? theme.colors.body : theme.colors.secondary};
     cursor: pointer;


### PR DESCRIPTION
Before:

<img width="619" alt="Screen Shot 2021-01-04 at 5 22 26 PM" src="https://user-images.githubusercontent.com/4732330/103589656-84419300-4eb1-11eb-85fe-3b1dfdc0ff3f.png">

After:

<img width="618" alt="Screen Shot 2021-01-04 at 5 22 44 PM" src="https://user-images.githubusercontent.com/4732330/103589664-873c8380-4eb1-11eb-821c-a3fa89f5f00a.png">
