### PR TITLE
feat(ssn): simplify SSNInput

### DIFF
--- a/src/stories.tsx
+++ b/src/stories.tsx
@@ -20,11 +20,7 @@ storiesOf('Base', module).add('SSN', () => (
   <Gutter withVertical>
     <Box mb='med'>
       <Label>Social Security Number</Label>
-      <SSNInput
-        value='123123123'
-        name='ssn'
-        placeholder='Enter your SSN here'
-      />
+      <SSNInput name='ssn' placeholder='Enter your SSN here' />
     </Box>
   </Gutter>
 ))
@@ -305,7 +301,7 @@ storiesOf('Formik', module).add('Basic', () => (
         toggle: '',
         date: '',
         dropdown: '',
-        ssn: '123-45-1234'
+        ssn: '***-**-1234'
       }}
       onSubmit={values => {
         const val = JSON.stringify(values, null, '  ')


### PR DESCRIPTION
Instead of trying to format-as-you-type (which is complex, error prone, and didn't work with our API response) this PR simply lets you edit the text directly when the field is focused, and only formats/masks the input on when unfocused.

See demo video. First input is `SSNInput` with no Formik, second input is within Formik and provided an initial value like `***-**-1234` to mimic the response from our Rv4 API.

https://user-images.githubusercontent.com/4732330/104351293-d8103580-54ca-11eb-8fc8-10d4ed2d9ce6.mov

