### PR TITLE
feat(component): add Tile radio button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 *.log
 .DS_Store
 node_modules

--- a/src/Tile.tsx
+++ b/src/Tile.tsx
@@ -1,0 +1,131 @@
+import * as React from 'react'
+import styled from 'styled-components'
+import { Field, FieldConfig, FieldProps } from 'formik'
+import { get } from 'lodash'
+import { Box, P } from '@truework/ui'
+
+export type TileProps = {
+  hasError?: boolean
+  name?: string
+  checked?: boolean
+  value: string
+  description?: React.ReactNode
+  icon?: React.ReactElement
+} & React.InputHTMLAttributes<HTMLInputElement>
+
+export type TileFieldProps = {
+  name: string
+} & Omit<TileProps, 'checked' | 'value'> &
+  Pick<FieldConfig, 'validate'>
+
+const TileButton = styled.label<{ checked?: boolean }>(
+  ({ theme, checked }) => `
+    width: 152px;
+    height: 136px;
+    background-color: ${theme.colors.background};  
+    padding: ${theme.space.med} ${theme.space.sm};
+    
+    text-align: center;
+    border-radius: ${theme.space.xxs};
+    
+    &:hover {
+      border: 1px solid ${theme.colors.primary};
+      background-color: rgb(91, 99, 254, 0.1);  
+    }
+    
+    ${
+      checked
+        ? `
+      border: 1px solid ${theme.colors.primary};
+      background-color: rgb(91, 99, 254, 0.1);        
+    `
+        : ``
+    }
+  `
+)
+
+const Input = styled.input`
+  appearance: none;
+`
+
+const TileGroup = styled.div<{ hasError: boolean }>(
+  ({ theme, hasError }) =>
+    `
+    display: flex;
+    
+    ${
+      hasError
+        ? `
+        border-color: ${theme.colors.error} !important;
+      `
+        : ``
+    }
+  `
+)
+
+export function Tile ({
+  children,
+  name,
+  checked,
+  description,
+  icon,
+  ...props
+}: TileProps) {
+  const id = name + props.value
+
+  return (
+    <>
+      <Input id={id} name={name} type='radio' checked={checked} {...props} />
+
+      <TileButton htmlFor={id} checked={checked}>
+        <Box display='flex' alignItems='center' justifyContent='center' mb='xs'>
+          {icon}
+        </Box>
+        <P fontSize={0} fontWeight={5} lineHeight={0} color='body'>
+          {description}
+        </P>
+      </TileButton>
+    </>
+  )
+}
+
+export function TileField ({
+  children,
+  name,
+  validate,
+  onChange,
+  onBlur,
+  ...rest
+}: React.PropsWithChildren<TileFieldProps>) {
+  return (
+    <Field name={name} validate={validate}>
+      {({ field, form }: FieldProps) => {
+        const hasError = Boolean(get(form, ['errors', name]))
+
+        return (
+          <TileGroup hasError={hasError}>
+            {React.Children.toArray(children).map(
+              (child: React.ReactElement) => {
+                return React.cloneElement(child, {
+                  ...field,
+                  ...rest,
+                  value: child.props.value,
+                  checked: Boolean(field.value === child.props.value),
+                  onChange (e: React.ChangeEvent<HTMLInputElement>) {
+                    field.onChange(e)
+                    if (onChange) onChange(e)
+                    console.log(child.props.value)
+                  },
+                  onBlur (e: React.FocusEvent<HTMLInputElement>) {
+                    field.onBlur(e)
+                    if (onBlur) onBlur(e)
+                  }
+                })
+              }
+            )}
+          </TileGroup>
+        )
+      }}
+    </Field>
+  )
+}

--- a/src/stories.tsx
+++ b/src/stories.tsx
@@ -15,6 +15,7 @@ import { Toggle, ToggleField } from './Toggle'
 import { DateInput, DateInputFieldWithLabel } from './DateInput'
 import { Dropdown, DropdownFieldWithLabel } from './Dropdown'
 import { SSNInput, SSNInputFieldWithLabel } from './SSNInput'
+import { Tile, TileField } from './Tile'
 
 storiesOf('Base', module).add('SSN', () => (
   <Gutter withVertical>
@@ -314,6 +315,22 @@ storiesOf('Formik', module).add('Basic', () => (
       }}
     >
       <Form>
+        <Box mb='med' display='flex' mr='sm'>
+          <TileField name='tile'>
+            <Tile
+              value='mortgage'
+              icon={<Icon name='FileText' width='48px' height='48px' />}
+              description='Mortgage / Home Equity'
+            />
+            <Tile
+              value='background'
+              icon={<Icon name='FileText' width='48px' height='48px' />}
+              description='Background Check / Employment Screen'
+            />
+            <Tile value='other' description='Other' />
+          </TileField>
+        </Box>
+
         <Box mb='med'>
           <InputFieldWithLabel name='input' label='Input' placeholder='Input' />
         </Box>


### PR DESCRIPTION
Designs: https://www.figma.com/file/8JrNIcp3VKD4MWwSEHFmkV/Verifier-Request-v5?node-id=481%3A83

Adding a Tile button that behaves similarly to a radio button, open to naming ideas!

