### PR TITLE
fix(ssn): clear SSN on edit if masked value is provided

### DIFF
--- a/src/SSNInput.tsx
+++ b/src/SSNInput.tsx
@@ -49,7 +49,12 @@ export function SSNInput (props: SSNInputProps) {
       onClick={activate}
       onBlur={deactivate}
       onChange={e => {
-        setRaw(clean(e.target.value))
+        const val = e.target.value
+
+        // clear on any change IF raw value (from API etc) has been masked
+        const shouldClear = /\*\*/.test(val)
+
+        setRaw(shouldClear ? '' : clean(val))
       }}
     />
   )


### PR DESCRIPTION
Thought we could do this at an app level, but better to handle it here I think. Basically, if you populate the field initially with a masked value, `***-**-1234`, any change of that value clears the field so you have to re-type it. Gotta be that way bc we don't know the actual value of course 😛 