### PR TITLE
feat(dateinputtypein): type-in date input

### DIFF
--- a/src/DateInputTypeIn.tsx
+++ b/src/DateInputTypeIn.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react'
+import { Label } from './Label'
+import styled, { css } from 'styled-components'
+import { Box, Icon } from '@truework/ui'
+import { Field, FieldProps } from 'formik'
+
+const Input = styled.input(
+  ({ theme }) => css`
+    font-family: ${theme.fonts.roboto};
+    color: ${theme.colors.body};
+    font-size: ${theme.fontSizes[1]};
+    font-family: ${theme.fonts.mono};
+    line-height: ${theme.lineHeights[0]};
+    letter-spacing: 0.6px;
+    border: none;
+    border-width: 0;
+    outline: none;
+
+    ::-webkit-calendar-picker-indicator {
+      display: none;
+    }
+  `
+)
+
+export function DateInputTypeIn ({
+  name,
+  hasError = false
+}: {
+  name: string
+  hasError?: boolean
+}) {
+  return (
+    <Box display='flex' alignItems='center' minHeight='48px'>
+      <Box zIndex={2} ml='56px' my='auto'>
+        <Input
+          type='date'
+          name={name}
+          min='1900-01-01'
+          max='2025-12-31'
+          placeholder=''
+        />
+      </Box>
+
+      <Box
+        className='__bg'
+        bg={hasError ? 'error-alpha01' : 'primary-alpha01'}
+        position='absolute'
+        top='-2px'
+        bottom='-2px'
+        left='-2px'
+        right='-2px'
+        zIndex={0}
+        borderRadius='6px'
+        opacity={0}
+        transitionProperty='opacity'
+        transitionDuration='fast'
+        transitionTimingFunction='ease'
+      />
+      <Box
+        className='__border'
+        bg='white'
+        border={['1px solid', hasError ? 'error' : 'outline']}
+        position='absolute'
+        top='0'
+        bottom='0'
+        left='0'
+        right='0'
+        zIndex={0}
+        borderRadius='4px'
+        transitionProperty='border-color'
+        transitionDuration='fast'
+        transitionTimingFunction='ease'
+      >
+        <Box
+          aria-hidden='true'
+          position='absolute'
+          top='0'
+          left='0'
+          display='flex'
+          alignItems='center'
+          justifyContent='center'
+          px='sm'
+          height='100%'
+          zIndex={0}
+          color={hasError ? 'error' : 'secondary'}
+          bg={hasError ? '#FDEBF0' : 'background'}
+          borderTopLeftRadius='4px'
+          borderBottomLeftRadius='4px'
+          borderRight={['1px solid', hasError ? 'error' : 'outline']}
+          transitionProperty='border-color, color'
+          transitionDuration='fast'
+          transitionTimingFunction='ease'
+        >
+          <Icon name='Calendar' />
+        </Box>
+      </Box>
+    </Box>
+  )
+}
+
+export function DateInputTypeInField ({ name }: { name: string }) {
+  return (
+    <Field name={name}>
+      {({ field, form }: FieldProps) => {
+        return <DateInputTypeIn name={name} />
+      }}
+    </Field>
+  )
+}
+
+export function DateInputTypeInFieldWithLabel ({
+  name,
+  label
+}: {
+  name: string
+  label: string
+}) {
+  return (
+    <>
+      <Label htmlFor={name}>{label}</Label>
+      <DateInputTypeInField name={name} />
+    </>
+  )
+}

--- a/src/stories.tsx
+++ b/src/stories.tsx
@@ -27,6 +27,7 @@ import { Dropdown, DropdownFieldWithLabel } from './Dropdown'
 import { SSNInput, SSNInputFieldWithLabel } from './SSNInput'
 import { Tile } from './Tile'
 import { ErrorMessage } from './ErrorMessage'
+import { DateInputTypeInFieldWithLabel } from './DateInputTypeIn'
 
 storiesOf('Base', module).add('SSN', () => (
   <Gutter withVertical>
@@ -464,6 +465,12 @@ storiesOf('Formik', module).add('Basic', () => (
         </Box>
         <Box mb='med'>
           <DateInputFieldWithLabel name='date' label='Date' />
+        </Box>
+        <Box mb='med'>
+          <DateInputTypeInFieldWithLabel
+            name='dateTypeIn'
+            label='Date Type In'
+          />
         </Box>
         <Box mb='med'>
           <DropdownFieldWithLabel

--- a/src/stories.tsx
+++ b/src/stories.tsx
@@ -27,7 +27,10 @@ import { Dropdown, DropdownFieldWithLabel } from './Dropdown'
 import { SSNInput, SSNInputFieldWithLabel } from './SSNInput'
 import { Tile } from './Tile'
 import { ErrorMessage } from './ErrorMessage'
-import { DateInputTypeInFieldWithLabel } from './DateInputTypeIn'
+import {
+  DateInputTypeIn,
+  DateInputTypeInFieldWithLabel
+} from './DateInputTypeIn'
 
 storiesOf('Base', module).add('SSN', () => (
   <Gutter withVertical>
@@ -261,6 +264,11 @@ storiesOf('Base', module).add('DateInput', () => (
     <Box mb='med'>
       <Label>Date</Label>
       <DateInput name='date' label='Date' onUpdate={() => {}} />
+    </Box>
+
+    <Box mb='med'>
+      <Label>Date Type In</Label>
+      <DateInputTypeIn name='dateTypeIn' />
     </Box>
   </Gutter>
 ))


### PR DESCRIPTION
Task: https://truework.atlassian.net/browse/SELF-131

Initial pass of a type-in Date Input. I'm using the native html date input here. Pros: gives us a smooth type in experience for free in for Chrome, Firefox. Cons: UX varies quite a lot depending on browser (in Safari and IE, it's just a blank input)

I explored [an alternative here](https://github.com/truework/forms/compare/angela/type-in-masked-date-input?expand=1), aiming to implement something closer to this example:

https://user-images.githubusercontent.com/59842325/127919504-970ba19b-ef54-48e8-b2af-2bcfffe1130d.mov

I think this alternative can give us one consistent experience across all browsers, but it gets a little tricky (I think we'll need to manipulate the cursor positioning?) and I can definitely explore this alternative further if we don't like the native one.


### Screenshots

Firefox:
- The calendar pops up automatically once the user clicks on this field. We can manually disable it, but that means we'd have to manually implement the clear button too. My thoughts are, it seems handy to keep the calendar here, pending design feedback.

https://user-images.githubusercontent.com/59842325/127917432-80cfc870-2006-40a7-8092-f1a55ebec8c4.mov

Chrome:
- We're able to hide the calendar picker on Chrome.

https://user-images.githubusercontent.com/59842325/127917501-d3733676-d810-4ad2-9453-90fc1b4b756c.mov


Safari:
- The native date picker is just a blank input field on Safari.

https://user-images.githubusercontent.com/59842325/127917511-d9959283-8ef4-4666-94e3-5f2b14a6e6d5.mov


IE (BrowserStack wasn't letting me type while recording, so took some screenshots):
- I'll need to look at the styling here.
- This one behaves a lot like the Safari experience, except it has a clear button.

<img width="379" alt="IE_DatePicker_blank" src="https://user-images.githubusercontent.com/59842325/127917563-b8a9cf74-6339-4432-be87-6125f6134d3f.png">
<img width="594" alt="IE_DatePicker_populated" src="https://user-images.githubusercontent.com/59842325/127917556-8920df60-b8ce-40ac-9aee-3f13af631555.png">
<img width="292" alt="IE_DatePicker_clear_button" src="https://user-images.githubusercontent.com/59842325/127917559-59179664-ea4d-44d0-abca-3dbd49c5198e.png">
