### PR TITLE
fix(dateinput): delete value

### DIFF
--- a/src/DateInput.tsx
+++ b/src/DateInput.tsx
@@ -419,6 +419,7 @@ export function DateInputTypeInField ({ name, ...rest }: InputProps) {
     <Field name={name} validate={validate}>
       {({ field, form }: FieldProps) => {
         const hasError = Boolean(get(form, ['errors', name]))
+        delete field.value
 
         return (
           <DateInputTypeIn


### PR DESCRIPTION
Was seeing the following error in the console: `Warning: 'value' prop on 'input' should not be null. Consider using an empty string to clear the component or 'undefined` for uncontrolled components.`

This DateTypeIn component is an uncontrolled component that uses the DOM (instead of React) to manage form data. We're currently passing down the `value` though, which is causing this error. Solution is to remove the value. Thanks Eric for helping me take a look at this!