### PR TITLE
fix(dateinput): typein date input value

### DIFF
--- a/src/DateInput.tsx
+++ b/src/DateInput.tsx
@@ -370,6 +370,7 @@ export function DateInputTypeIn ({
   hasError,
   onChange,
   onBlur,
+  value,
   ...rest
 }: InputProps) {
   return (
@@ -381,6 +382,7 @@ export function DateInputTypeIn ({
       type='text'
       onChange={onChange}
       onBlur={onBlur}
+      value={value}
       render={(inputRef, props) => (
         <Input
           name={name}
@@ -419,7 +421,6 @@ export function DateInputTypeInField ({ name, ...rest }: InputProps) {
     <Field name={name} validate={validate}>
       {({ field, form }: FieldProps) => {
         const hasError = Boolean(get(form, ['errors', name]))
-        delete field.value
 
         return (
           <DateInputTypeIn


### PR DESCRIPTION
Was seeing that going back and forth between steps in RV4, this input would lose it's value.

I'm thinking to solve the previous issue, maybe we just need to exclude `value` from `rest` instead of deleting it.