### PR TITLE
fix(dateinput): fix validation so date isn't always required

### DIFF
--- a/src/DateInput.tsx
+++ b/src/DateInput.tsx
@@ -398,9 +398,7 @@ export function DateInputTypeIn ({
 
 export function DateInputTypeInField ({ name, ...rest }: InputProps) {
   const validate = React.useCallback((value: string) => {
-    if (!value) {
-      return 'Required'
-    }
+    if (!value) return
 
     const moment = require('moment')
     const [month, day, year] = value.split('/').map(v => parseInt(v))

--- a/src/DateInput.tsx
+++ b/src/DateInput.tsx
@@ -7,7 +7,7 @@ import { Box, Icon } from '@truework/ui'
 import { getLastDayOfMonth, zeroPadDate } from './utils/date'
 import { Label } from './Label'
 import MaskedInput from 'react-text-mask'
-import { Input, InputProps } from './Input'
+import { Input, InputFieldProps, InputProps } from './Input'
 
 export type DateValidationOptions = {
   initialMonth?: number
@@ -396,11 +396,13 @@ export function DateInputTypeIn ({
   )
 }
 
-export function DateInputTypeInField ({ name, ...rest }: InputProps) {
-  const validate = React.useCallback((value: string) => {
-    if (!value) {
-      return 'Required'
-    }
+export function DateInputTypeInField ({
+  name,
+  validate,
+  ...rest
+}: InputFieldProps) {
+  const isValidDate = React.useCallback((value: string) => {
+    if (!value) return
 
     const moment = require('moment')
     const [month, day, year] = value.split('/').map(v => parseInt(v))
@@ -418,7 +420,16 @@ export function DateInputTypeInField ({ name, ...rest }: InputProps) {
   }, [])
 
   return (
-    <Field name={name} validate={validate}>
+    <Field
+      name={name}
+      validate={(value: string) => {
+        if (validate) {
+          return validate(value) || isValidDate(value)
+        }
+
+        return isValidDate(value)
+      }}
+    >
       {({ field, form }: FieldProps) => {
         const hasError = Boolean(get(form, ['errors', name]))
 

--- a/src/DateInput.tsx
+++ b/src/DateInput.tsx
@@ -398,7 +398,9 @@ export function DateInputTypeIn ({
 
 export function DateInputTypeInField ({ name, ...rest }: InputProps) {
   const validate = React.useCallback((value: string) => {
-    if (!value) return
+    if (!value) {
+      return 'Required'
+    }
 
     const moment = require('moment')
     const [month, day, year] = value.split('/').map(v => parseInt(v))

--- a/src/stories.tsx
+++ b/src/stories.tsx
@@ -483,7 +483,10 @@ storiesOf('Formik', module).add('Basic', () => (
         </Box>
         <Box mb='med'>
           <Label>Date Type-In</Label>
-          <DateInputTypeInField name='dateTypeIn' />
+          <DateInputTypeInField
+            name='dateTypeIn'
+            validate={val => (val ? undefined : 'Failed custom validate')}
+          />
           <ErrorMessage name='dateTypeIn' />
         </Box>
 


### PR DESCRIPTION
~I was returning an error in the validation function if the value wasn't present. We should leave that up to the wrapping Formik validation schema to determine whether this field is required or not.~

Adding support for a custom `validate` function as well as always running the built in date validation if a value is present.